### PR TITLE
ci(release): trigger release on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         type: string
         required: false
 concurrency:
-  group: release-${{ github.repository }}-${{ github.ref_name }}
+  group: release-${{ github.repository }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 on:
   push:
+    branches: [main]
     tags: ['v*']
   workflow_dispatch:
     inputs:
@@ -12,6 +13,10 @@ on:
         description: 'Exact version to release (e.g. 1.0.0). Overrides bump logic.'
         type: string
         required: false
+concurrency:
+  group: release-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
   release:
     uses: plures/.github/.github/workflows/release-reusable.yml@main
     with:
-      bump: ${{ inputs.bump || '' }}
-      target_version: ${{ inputs.target_version || '' }}
+      bump: ${{ github.event.inputs.bump || '' }}
+      target_version: ${{ github.event.inputs.target_version || '' }}
     secrets: inherit


### PR DESCRIPTION
Adds a push: branches: [main] trigger to the release workflow so merging to main auto-triggers the release pipeline, matching the validated pattern in plures/chronos#107 and plures/.github#13. Also adds/confirms a concurrency guard.

Mechanical sweep, part of org:release-trigger-autobump.